### PR TITLE
Added grunt files with html, css, and js lint tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /hooks
 /platforms
 /plugins
+/node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+/*global module, require*/
+
+module.exports = function (grunt) {
+  'use strict';
+  
+  // URI paths for our tasks to use.
+  grunt.uri = './';
+  
+  grunt.uriWww = grunt.uri + 'www/';
+  grunt.uriSrc = grunt.uriWww + 'src/';
+  grunt.uriGame = grunt.uriSrc + 'game/';
+  
+  grunt.uriTools = grunt.uri + 'tools/';
+  grunt.uriTask = grunt.uriTools + 'grunt/';
+  
+  grunt.uriBuild = grunt.uri + 'build/';
+
+  // Our task object where we'll store our configuration.
+  var tasks = {};
+  tasks.concat = {};
+
+  // Lint Tasks
+  tasks = require(grunt.uriTask + 'csslint.js')(grunt, tasks);
+  tasks = require(grunt.uriTask + 'htmllint.js')(grunt, tasks);
+  tasks = require(grunt.uriTask + 'jshint.js')(grunt, tasks);
+
+  // Register Tasks
+  grunt.registerTask('lint', ['csslint', 'htmllint', 'jshint']);
+  grunt.registerTask('default', ['lint']);
+
+  // Initialize The Grunt Configuration
+  grunt.initConfig(tasks);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "gjweb",
+  "description": "Web based game template for game jams.",
+  "dependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-concat": "^0.4.0",
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-csslint": "^0.2.0",
+    "grunt-contrib-cssmin": "^0.10.0",
+    "grunt-contrib-htmlmin": "^0.3.0",
+    "grunt-contrib-uglify": "^0.4.0",
+    "grunt-html": "^1.4.0",
+    "csslint": "^0.10.0",
+    "phaser": "^2.4.4",
+    "three": "^0.73.0",
+    "grunt-nw-builder": "^2.0.0",
+    "cordova": "^5.3.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/puzzud/gjweb.git"
+  },
+  "bugs": "https://github.com/puzzud/gjweb/issues",
+  "author": "",
+  "license": "MIT"
+}

--- a/tools/grunt/csslint.js
+++ b/tools/grunt/csslint.js
@@ -1,0 +1,21 @@
+/*global module*/
+
+module.exports = function (grunt, tasks) {
+  'use strict';
+
+  // Load our node module required for this task.
+  grunt.loadNpmTasks('grunt-contrib-csslint');
+
+  // The configuration for a specific task.
+  tasks.csslint = {
+    // The files that we want to check.
+    dist: {
+      src: [
+        grunt.uriWww + '*.css', // Include all CSS files in this directory.
+        grunt.uriWww + '!*.min.css' // Exclude any files ending with `.min.css`
+      ]
+    }
+  };
+
+  return tasks;
+};

--- a/tools/grunt/htmllint.js
+++ b/tools/grunt/htmllint.js
@@ -1,0 +1,27 @@
+/*global module*/
+
+module.exports = function (grunt, tasks) {
+  'use strict';
+
+  // Load our node module required for this task.
+  grunt.loadNpmTasks('grunt-html');
+
+  // The configuration for a specific task.
+  tasks.htmllint = {
+    // The files that we want to check.
+    dist: {
+    options: {
+      path: false,
+      reportpath: false // Turns logging to a file off, output will show in the CLI.
+    },
+
+    // The files that we want to check.
+    src: [
+      grunt.uriWww + '*.html', // Include all HTML files in this directory.
+      '!' + grunt.uriWww + '*.min.html' // Exclude any files ending with `.min.html`
+      ]
+    }
+  };
+
+  return tasks;
+};

--- a/tools/grunt/jshint.js
+++ b/tools/grunt/jshint.js
@@ -1,0 +1,21 @@
+/*global module*/
+
+module.exports = function (grunt, tasks) {
+  'use strict';
+  
+  // Load our node module required for this task.
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+
+  // The configuration for a specific task.
+  tasks.jshint = {
+    // The files that we want to check.
+    dist: {
+      src: [
+        grunt.uriGame + '*.js', // Include all JS files in this directory.
+        '!' + grunt.uriGame + '*.min.js' // Exclude any files ending with `.min.js`
+      ]
+    }
+  };
+
+  return tasks;
+};


### PR DESCRIPTION
@puzzud 

Here are the files for html, css, and js linting using grunt. I'll hold off adding concat and minify grunt tasks until I better understand cordova's role and how builds will be organized in the project. I also didn't change the README.md instructions for how to setup project dependencies because that would affect script paths in both the development index.html and final build index.html. I can add a wiki page for how to lint if you would like. There are 5 possible commands:

Lint html files: `grunt htmllint`
Lint css files: `grunt csslint`
JsHint: `grunt jshint`

To lint html, css, and js using one command: `grunt lint`

I made `grunt lint` the default grunt task. So performing `grunt` is the same as `grunt lint`.

The 'files to lint' paths for each of the grunt tasks are specified in the grunt task files themselves, ie /tools/grunt/csslint.js. Those paths will need to be updated if the src files move directories or if more src files are added elsewhere. 
